### PR TITLE
Store config in class

### DIFF
--- a/src/rule_loader.ts
+++ b/src/rule_loader.ts
@@ -1,35 +1,31 @@
-import fs from 'node:fs'
 import path from 'node:path'
+import { existsSync } from 'node:fs'
 import { pathToFileURL } from 'node:url'
 
 import Rule from './rule'
 import Document from './document'
-import { GherklinConfiguration, LintError, RawSchema } from './types'
+import { LintError, RawSchema } from './types'
+import Config from './config'
 
 export default class RuleLoader {
-  private config: GherklinConfiguration
+  private config: Config
 
   private rules: Array<Rule> = []
 
-  public constructor(config: GherklinConfiguration) {
+  public constructor(config: Config) {
     this.config = config
   }
 
-  public load = async (
-    configLocation: string,
-    ruleName: string,
-    rawSchema: RawSchema,
-    customDir?: string,
-  ): Promise<void> => {
+  public load = async (ruleName: string, rawSchema: RawSchema, customDir?: string): Promise<void> => {
     let location = path.resolve(import.meta.dirname, `./rules/${ruleName}.ts`)
 
     // If this rule doesn't appear in the defaults, we'll need to look for it in the custom rules dir
-    if (!fs.existsSync(location)) {
+    if (!existsSync(location)) {
       if (customDir) {
         // Import files relative to the location of the config file
-        const customLocation = path.join(configLocation, customDir, `${ruleName}.ts`)
+        const customLocation = path.join(this.config.configDirectory, customDir, `${ruleName}.ts`)
 
-        if (!fs.existsSync(customLocation)) {
+        if (!existsSync(customLocation)) {
           throw new Error(`could not find rule "${ruleName}" in default rules or "${customDir}".`)
         }
         location = customLocation

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -16,7 +16,7 @@ import Document from './document'
 export default class Runner {
   public gherkinFiles: Array<string> = []
 
-  private config: GherklinConfiguration
+  private config: Config
 
   private reporter: Reporter
 
@@ -24,7 +24,7 @@ export default class Runner {
 
   constructor(gherklinConfig?: GherklinConfiguration) {
     if (gherklinConfig) {
-      this.config = new Config().fromInline(gherklinConfig)
+      this.config = new Config(gherklinConfig)
     }
   }
 
@@ -47,12 +47,7 @@ export default class Runner {
 
     // Import and validate all default rules
     for (const ruleName in this.config.rules) {
-      await this.ruleLoader.load(
-        this.config.configDirectory,
-        ruleName,
-        this.config.rules[ruleName],
-        this.config.customRulesDirectory,
-      )
+      await this.ruleLoader.load(ruleName, this.config.rules[ruleName], this.config.customRulesDirectory)
 
       const schemaErrors = this.ruleLoader.validateRules()
       if (schemaErrors.size) {

--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -2,14 +2,15 @@ import { expect, use } from 'chai'
 import chaiAsPromised from 'chai-as-promised'
 import sinon from 'sinon'
 
+import { Switch } from '../../src'
 import Config from '../../src/config'
 
 use(chaiAsPromised)
 
 describe('Config', () => {
-  const config = new Config()
-
   describe('fromFile', () => {
+    const config = new Config()
+
     it('can handle no file found', async () => {
       sinon.stub(process, 'cwd').value(() => './invalid/path')
       await expect(config.fromFile()).to.be.rejectedWith(Error, 'could not find gherklin.config.ts')
@@ -18,6 +19,47 @@ describe('Config', () => {
     it('can handle no default export in config file', async () => {
       sinon.stub(process, 'cwd').value(() => import.meta.dirname)
       await expect(config.fromFile()).to.be.rejectedWith(Error, 'config file did not export a default function')
+    })
+  })
+
+  describe('validate', () => {
+    it('throws if theres no featureDirectory and featureFile', () => {
+      expect(() => new Config({})).to.throw(
+        Error,
+        'Please specify either a featureDirectory or featureFile configuration option.',
+      )
+    })
+
+    it('throws if theres no rules', () => {
+      expect(
+        () =>
+          new Config({
+            featureFile: 'test.feature',
+          }),
+      ).to.throw(Error, 'Please specify a list of rules in your configuration.')
+    })
+
+    it('throws if theres rules but the object is empty', () => {
+      expect(
+        () =>
+          new Config({
+            featureFile: 'test.feature',
+            rules: {},
+          }),
+      ).to.throw(Error, 'Please specify a list of rules in your configuration.')
+    })
+
+    it('throws if featureFile and featureDirectory are passed', () => {
+      expect(
+        () =>
+          new Config({
+            featureFile: 'test.feature',
+            featureDirectory: '.',
+            rules: {
+              'allowed-tags': Switch.on,
+            },
+          }),
+      ).to.throw(Error, 'Please only specify either a feature file or feature directory.')
     })
   })
 })

--- a/tests/unit/rule_loader.test.ts
+++ b/tests/unit/rule_loader.test.ts
@@ -2,16 +2,24 @@ import { expect, use } from 'chai'
 import chaiAsPromised from 'chai-as-promised'
 import RuleLoader from '../../src/rule_loader'
 import { Switch } from '../../src'
+import Config from '../../src/config'
 
 use(chaiAsPromised)
 
 describe('RuleLoader', () => {
-  const loader = new RuleLoader({})
+  const config = new Config({
+    configDirectory: '.',
+    featureFile: 'test.feature',
+    rules: {
+      'allowed-tags': ['@development'],
+    },
+  })
+  const loader = new RuleLoader(config)
 
   describe('load', () => {
     context('no custom directory specified', () => {
       it('handles no rule in default rules', async () => {
-        const load = loader.load('.', 'a-rule', Switch.on)
+        const load = loader.load('a-rule', Switch.on)
         await expect(load).to.be.rejectedWith(
           Error,
           'could not find rule "a-rule" in default rules.\nIf this is a custom rule, please specify "customRulesDirectory" in the config.',
@@ -21,7 +29,7 @@ describe('RuleLoader', () => {
 
     context('custom directory specified', () => {
       it('handles no rule in default rules or custom rules', async () => {
-        const load = loader.load('.', 'a-rule', Switch.on, '.')
+        const load = loader.load('a-rule', Switch.on, '.')
         await expect(load).to.be.rejectedWith(Error, 'could not find rule "a-rule" in default rules or ".".')
       })
     })


### PR DESCRIPTION
The config class was just a holder of a couple of utility functions, which then returned an object using the GherklinConfiguration interface.

This PR changes it so that the configuration is stored on the config class, and everything uses that class rather than using the interface everywhere.