### PR TITLE
Allow specific rules to be specified using gherklin-disable-next-line

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,16 @@ Feature: The below tag is invalid
   Scenario:
 ```
 
+This also works for disabling rules on the next line.
+
+### Example
+```gherkin
+Feature: The below tag is invalid
+  @invalid-tag
+  # gherklin-disable-next-line no-unnamed-scenario
+  Scenario:
+```
+
 # Automatic Fixing
 
 Gherklin supports automatic fixing for a small set of rules, usually those to do with whitespace.

--- a/src/rules/indentation.ts
+++ b/src/rules/indentation.ts
@@ -18,6 +18,9 @@ export default class Indentation implements Rule {
 
   public async run(document: Document): Promise<void> {
     const args = this.schema.args as GherkinKeywordNumericals
+    if (!args) {
+      return
+    }
 
     if (args.feature !== undefined) {
       if (document.feature.location.column !== args.feature) {

--- a/tests/acceptance/features/disable-comments.feature
+++ b/tests/acceptance/features/disable-comments.feature
@@ -90,6 +90,66 @@ Feature: Disabling Comments
       | {"no-unnamed-scenarios": "on"} |
     Then there are 1 file with errors
 
+  Scenario: Disable next line with specific rules
+    Given the following feature file
+        """
+        Feature: Empty Scenario
+          # gherklin-disable-next-line no-unnamed-scenarios
+          Scenario:
+        """
+    When Gherklin is ran with the following configuration
+      | rules                          |
+      | {"no-unnamed-scenarios": "on"} |
+    Then there are 0 files with errors
+
+  Scenario: Disable next line with multiple specific rules
+    Given the following feature file
+        """
+        Feature: Empty Scenario
+          # gherklin-disable-next-line no-unnamed-scenarios, indentation
+          Scenario:
+        """
+    When Gherklin is ran with the following configuration
+      | rules                          |
+      | {"no-unnamed-scenarios": "on", "indentation": {"scenario": 0}} |
+    Then there is 0 files with errors
+
+  Scenario: Disable next line with specific rules regardless of indentation
+    Given the following feature file
+        """
+        Feature: Empty Scenario
+              # gherklin-disable-next-line no-unnamed-scenarios
+          Scenario:
+        """
+    When Gherklin is ran with the following configuration
+      | rules                          |
+      | {"no-unnamed-scenarios": "on"} |
+    Then there are 0 files with errors
+
+  Scenario: Disable next line with specific rules but comment is not correctly formatted
+    Given the following feature file
+        """
+        Feature: Empty Scenario
+          #gherklin-disable-next-line no-unnamed-scenarios
+          Scenario:
+        """
+    When Gherklin is ran with the following configuration
+      | rules                          |
+      | {"no-unnamed-scenarios": "on"} |
+    Then there are 1 files with errors
+
+  Scenario: Disable next line with specific rules with no space between rules
+    Given the following feature file
+        """
+        Feature: Empty Scenario
+          # gherklin-disable-next-line no-unnamed-scenarios,indentation
+          Scenario:
+        """
+    When Gherklin is ran with the following configuration
+      | rules                          |
+      | {"no-unnamed-scenarios": "on", "indentation": {"scenario": 0}} |
+    Then there are 0 files with errors
+
   Scenario: Disable specific rule
     Given the following feature file
         """


### PR DESCRIPTION
Resolves: https://github.com/cjmarkham/Gherklin/issues/123

**Prerequisites**
- [x] I have added tests to cover my change
- [x] If applicable, I've documented changes in the README
- [x] I've read the [Contributing Guidelines](../CONTRIBUTING.md)

**What is the purpose of this pull request?**
- [ ] New rule
- [ ] Bug fix
- [ ] Documentation update
- [ ] Changing an existing rule
- [x] Add something to the core of Gherklin
- [ ] Other (please explain)

**Please give an overview of your changes**
Enables the use of specific rules when using the `# gherklin-disable-next-line` comment.