### PR TITLE
Allow conjunctions when keywords-logical-order enabled

### DIFF
--- a/src/rules/keywords-in-logical-order.ts
+++ b/src/rules/keywords-in-logical-order.ts
@@ -35,26 +35,31 @@ export default class KeywordsInLogicalOrder implements Rule {
         const when = dialect.when.filter((w) => w !== '* ')
         const then = dialect.then.filter((w) => w !== '* ')
         const and = dialect.and.filter((w) => w !== '* ')
+        const but = dialect.but.filter((w) => w !== '* ')
         const trimmedWhen = when.map((w) => w.trim())
         const trimmedThen = then.map((w) => w.trim())
         const trimmedAnd = and.map((w) => w.trim())
+        const trimmedBut = but.map((w) => w.trim())
 
-        if (given.includes(step.keyword) && !when.includes(nextStep.keyword)) {
+        // Check for Given, followed by When, And or But
+        if (given.includes(step.keyword) && ![...and, ...but, ...when].includes(nextStep.keyword)) {
           document.addError(
             this,
-            `Expected "${step.keyword.trim()}" to be followed by "${trimmedWhen.join(', ')}", got "${nextTrimmed}"`,
+            `Expected "${step.keyword.trim()}" to be followed by "${[...trimmedAnd, ...trimmedBut, ...trimmedWhen].join(', ')}", got "${nextTrimmed}"`,
             step.location,
           )
         }
 
-        if (when.includes(step.keyword) && !then.includes(nextStep.keyword)) {
+        // Check for When, followed by Then, And or But
+        if (when.includes(step.keyword) && ![...and, ...but, ...then].includes(nextStep.keyword)) {
           document.addError(
             this,
-            `Expected "${step.keyword.trim()}" to be followed by "${trimmedThen.join(', ')}", got "${nextTrimmed}"`,
+            `Expected "${step.keyword.trim()}" to be followed by "${[...trimmedAnd, ...trimmedBut, ...trimmedThen].join(', ')}", got "${nextTrimmed}"`,
             step.location,
           )
         }
 
+        // Check for Then, followed by And or When
         if (then.includes(step.keyword) && ![...and, ...when].includes(nextStep.keyword)) {
           document.addError(
             this,

--- a/tests/acceptance/features/keywords-in-logical-order.feature
+++ b/tests/acceptance/features/keywords-in-logical-order.feature
@@ -6,6 +6,7 @@ Feature: Keywords in Logical Order
       Feature: Keywords in Logical Order
         Scenario: Invalid
           Then something should have happened
+          And something didn't happen
           When something happens
           Given I do something
           And another thing didn't happen
@@ -16,8 +17,7 @@ Feature: Keywords in Logical Order
     Then there is 1 file with errors
     And the errors are
       | location                 | severity | rule                      | message                                               |
-      | {"line": 4, "column": 5} | warn     | keywords-in-logical-order | Expected "When" to be followed by "Then", got "Given" |
-      | {"line": 5, "column": 5} | warn     | keywords-in-logical-order | Expected "Given" to be followed by "When", got "And"  |
+      | {"line": 5, "column": 5} | warn     | keywords-in-logical-order | Expected "When" to be followed by "And, But, Then", got "Given" |
 
   Scenario: Valid Order
     Given the following feature file
@@ -33,3 +33,16 @@ Feature: Keywords in Logical Order
       | rules                               |
       | {"keywords-in-logical-order": "on"} |
     Then there is 0 files with errors
+
+  Scenario: Conjunction step
+    Given the following feature file
+      """
+      Feature: Keywords in Logical Order
+        Scenario: Invalid
+          Given I have shades
+          And I have a brand new Mustang
+      """
+    When Gherklin is ran with the following configuration
+      | rules                               |
+      | {"keywords-in-logical-order": "on"} |
+    Then there are 0 files with errors


### PR DESCRIPTION
Resolves: https://github.com/cjmarkham/Gherklin/issues/121

**Prerequisites**
- [x] I have added tests to cover my change
- [x] If applicable, I've documented changes in the README
- [x] I've read the [Contributing Guidelines](../CONTRIBUTING.md)

**What is the purpose of this pull request?**
- [ ] New rule
- [ ] Bug fix
- [ ] Documentation update
- [x] Changing an existing rule
- [ ] Add something to the core of Gherklin
- [ ] Other (please explain)

**Please give an overview of your changes**
Changes `keywords-logical-order` rule to allow conjunctions