### PR TITLE
Fix instances where scenario would take precedence over scenario outline

### DIFF
--- a/gherklin.config.ts
+++ b/gherklin.config.ts
@@ -19,6 +19,7 @@ export default {
         but: 5,
         exampleTableHeader: 7,
         exampleTableBody: 7,
+        scenarioOutline: 3,
       },
     ],
     'new-line-at-eof': 'warn',

--- a/src/line.ts
+++ b/src/line.ts
@@ -1,5 +1,5 @@
 import { dialects } from '@cucumber/gherkin'
-import {camelise} from "./utils";
+import { camelise } from './utils'
 
 export default class Line {
   public keyword: string = ''

--- a/src/line.ts
+++ b/src/line.ts
@@ -1,7 +1,10 @@
 import { dialects } from '@cucumber/gherkin'
+import {camelise} from "./utils";
 
 export default class Line {
   public keyword: string = ''
+
+  public safeKeyword: string = ''
 
   public text: string = ''
 
@@ -15,13 +18,15 @@ export default class Line {
       .filter((kw) => kw[0] !== 'name' && kw[0] !== 'native')
       .map((kw) => kw[1])
       .flat()
-    const regex = new RegExp(`^(${keywords.map((k: string) => k.replaceAll('*', '\\*')).join('|')})`)
+      .sort((a, b) => b < a ? -1 : 1)
 
+    const regex = new RegExp(`^(${keywords.map((k: string) => k.replaceAll('*', '\\*')).join('|')})`)
     const keywordMatch = line.trim().match(regex)
     if (keywordMatch) {
       this.keyword = keywordMatch[0]
+      this.safeKeyword = camelise(this.keyword).trim()
       this.indentation = line.length - line.trimStart().length
-      this.text = line.replace(this.keyword, '').trimStart()
+      this.text = line.replace(keywordMatch[0], '').trimStart()
     }
   }
 }

--- a/src/rules/indentation.ts
+++ b/src/rules/indentation.ts
@@ -44,10 +44,11 @@ export default class Indentation implements Rule {
       }
 
       if (child.scenario && args.scenario !== undefined) {
-        if (child.scenario.location.column !== args.scenario) {
+        const scenarioType = child.scenario.keyword === 'Scenario Outline' ? 'scenarioOutline' : 'Scenario'
+        if (child.scenario.location.column !== args[scenarioType]) {
           document.addError(
             this,
-            `Invalid indentation for scenario. Got ${child.scenario.location.column}, wanted ${args.scenario}`,
+            `Invalid indentation for ${child.scenario.keyword}. Got ${child.scenario.location.column}, wanted ${args[scenarioType]}`,
             child.scenario.location,
           )
         }
@@ -122,7 +123,7 @@ export default class Indentation implements Rule {
     const expectedIndentation = this.schema.args as GherkinKeywordNumericals
 
     document.lines.forEach((line: Line, index: number) => {
-      const expected = expectedIndentation[line.keyword.trim().toLowerCase()]
+      const expected = expectedIndentation[line.safeKeyword]
       if (expected) {
         document.lines[index].indentation = expected - 1
       }

--- a/src/rules/indentation.ts
+++ b/src/rules/indentation.ts
@@ -43,14 +43,16 @@ export default class Indentation implements Rule {
         }
       }
 
-      if (child.scenario && args.scenario !== undefined) {
-        const scenarioType = child.scenario.keyword === 'Scenario Outline' ? 'scenarioOutline' : 'Scenario'
-        if (child.scenario.location.column !== args[scenarioType]) {
-          document.addError(
-            this,
-            `Invalid indentation for ${child.scenario.keyword}. Got ${child.scenario.location.column}, wanted ${args[scenarioType]}`,
-            child.scenario.location,
-          )
+      if (child.scenario) {
+        const scenarioType = child.scenario.keyword === 'Scenario Outline' ? 'scenarioOutline' : 'scenario'
+        if (scenarioType in args) {
+          if (child.scenario.location.column !== args[scenarioType]) {
+            document.addError(
+              this,
+              `Invalid indentation for ${scenarioType}. Got ${child.scenario.location.column}, wanted ${args[scenarioType]}`,
+              child.scenario.location,
+            )
+          }
         }
       }
 

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -16,6 +16,7 @@ export const keywordInts = z
     but: z.number(),
     exampleTableHeader: z.number(),
     exampleTableBody: z.number(),
+    scenarioOutline: z.number(),
   })
   .partial()
   .strict()

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -17,7 +17,7 @@ export const camelise = (str: string): string => str
   .split(' ')
   .map((e,i) => i
       ? e.charAt(0).toUpperCase() + e.slice(1).toLowerCase()
-      : e.toLowerCase()
+      : e.toLowerCase(),
   )
   .join('')
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -13,6 +13,14 @@ export const getFiles = async (dir: string, ext: string): Promise<Array<string>>
   return Array.prototype.concat(...files)
 }
 
+export const camelise = (str: string): string => str
+  .split(' ')
+  .map((e,i) => i
+      ? e.charAt(0).toUpperCase() + e.slice(1).toLowerCase()
+      : e.toLowerCase()
+  )
+  .join('')
+
 // https://gist.github.com/keesey/e09d0af833476385b9ee13b6d26a2b84
 export function levenshtein(a: string, b: string): number {
   const an = a ? a.length : 0

--- a/tests/acceptance/features/indentation.feature
+++ b/tests/acceptance/features/indentation.feature
@@ -44,14 +44,12 @@ Feature: Indentation
     Given the following feature file
       """
       Feature: Invalid Tag
-      Scenario: Doing something
-          Given I do something
-         When I do another thing
-                Then I should have done something
-             And another thing
-       But not done nothing
+      Scenario Outline: Doing something
       """
     When Gherklin is ran with the following configuration
-      | rules                                                                                                | fix  |
-      | {"indentation": {"feature": 1, "scenario": 3, "given": 5, "when": 5, "then": 5, "and": 5, "but": 5}} | true |
-    Then there is 0 files with errors
+      | rules                                                                                                                       | fix  |
+      | {"indentation": {"feature": 1, "scenario": 3, "given": 5, "when": 5, "then": 5, "and": 5, "but": 5, "scenarioOutline": 3}} | true |
+    Then there are 0 files with errors
+    And the file has the content
+      | line | content                           |
+      | 2    | Scenario Outline: Doing something |


### PR DESCRIPTION
**Prerequisites**
- [x] I have added tests to cover my change
- [x] If applicable, I've documented changes in the README
- [x] I've read the [Contributing Guidelines](../CONTRIBUTING.md)

**What is the purpose of this pull request?**
- [ ] New rule
- [x] Bug fix
- [ ] Documentation update
- [ ] Changing an existing rule
- [ ] Add something to the core of Gherklin
- [ ] Other (please explain)

**Please give an overview of your changes**
Scenario outline wasn't being matched correctly because scenario keyword would be matched first.
This change sorts the keywords in descending order to give Scenario Outline priority.